### PR TITLE
Messages storing and improved test tooling

### DIFF
--- a/src/main/java/com/gmzcodes/chainchat/models/Conversation.java
+++ b/src/main/java/com/gmzcodes/chainchat/models/Conversation.java
@@ -1,23 +1,84 @@
 package com.gmzcodes.chainchat.models;
 
+import static java.util.Arrays.asList;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
 /**
  * Created by danigamez on 10/11/2016.
  */
 public class Conversation {
 
-    private String userA = "";
-    private String userB = "";
-    private String roomId = "";
+    private final static String SEPARATOR = "::";
+    private final static String IDENTIFIER_BASE = "timestamp";
+    private final static String IDENTIFIER_FINAL = "id";
 
-    public Conversation(String userA, String userB) {
-        if (userA.compareTo(userB) <= 0) {
-            this.userA = userA;
-            this.userB = userB;
-        } else { // Swap them...
-            this.userA = userA;
-            this.userB = userB;
+    private List<String> usernames = new ArrayList<>();
+    private String roomId = "";
+    private Map<String, JsonObject> messages = new LinkedHashMap<>();
+
+    public Conversation(String... usernames) {
+        this.usernames = Arrays.stream(usernames).distinct().sorted().collect(Collectors.toList());
+        this.roomId = buildRoomId(this.usernames);
+    }
+
+    private static String buildRoomId(List<String> usernames) {
+        return String.join(SEPARATOR, usernames.stream().distinct().sorted().collect(Collectors.toList()));
+    }
+
+    public static String buildRoomId(String... usernames) {
+        return buildRoomId(asList(usernames));
+    }
+
+    public String getRoomId() {
+        return this.roomId;
+    }
+
+    public String getRoomIdForUser(String username) throws Exception {
+        int position = usernames.indexOf(username);
+
+        if (position != -1){
+            if (position == 0) {
+                return this.roomId.replace(username + SEPARATOR, "");
+            } else if (position == usernames.size() - 1) {
+                return this.roomId.replace(SEPARATOR + username, "");
+            } else {
+                return this.roomId.replace(SEPARATOR + username + SEPARATOR, SEPARATOR);
+            }
+        } else {
+            throw new Exception("User " + username + " not part of this conversation.");
+        }
+    }
+
+    public JsonObject putMessage(JsonObject message) {
+        // TODO: States of the message (seen, etc) should be stored per user!
+
+        String baseIdentifier = message.getString("username") + "::" + message.getString(IDENTIFIER_BASE);
+
+        String finalIdentifier = baseIdentifier;
+        int index = 0;
+
+        while (messages.containsKey(finalIdentifier)) {
+            finalIdentifier = baseIdentifier + "." + (++index);
         }
 
-        this.roomId = this.userA + "::" + this.userB;
+        // TODO: Messages should be stored with ack from server already!
+
+        message.put(IDENTIFIER_FINAL, finalIdentifier);
+        messages.put(finalIdentifier, message);
+
+        return message;
+    }
+
+    public JsonArray toJson() {
+        JsonArray jsonMessages = new JsonArray();
+
+        messages.values().forEach(jsonMessages::add);
+
+        return jsonMessages;
     }
 }

--- a/src/main/java/com/gmzcodes/chainchat/routes/api/auth/AuthAPIRoutes.java
+++ b/src/main/java/com/gmzcodes/chainchat/routes/api/auth/AuthAPIRoutes.java
@@ -70,13 +70,15 @@ public final class AuthAPIRoutes {
 
                 ctx.setUser(login.result());
 
-                sessionsStore.put(ctx.session().id(), username);
+                try {
+                    sessionsStore.putSession(ctx.session().id(), username);
+                } catch (Exception e) {
+                    ctx.fail(500); // 500 INTERNAL SERVER ERROR // TODO: Test this
+                }
 
                 JsonObject response = usersStore.get(username);
                 response.put("conversations", conversationsStore.getJson(username));
                 response.put("token", tokensStore.generate(username).getId());
-
-                // TODO: Return user and all user data (conversarions missing)
 
                 ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(response.toString());
             });

--- a/src/main/java/com/gmzcodes/chainchat/store/SessionsStore.java
+++ b/src/main/java/com/gmzcodes/chainchat/store/SessionsStore.java
@@ -15,12 +15,14 @@ public class SessionsStore {
 
     public SessionsStore() {}
 
-    public String get(String sessionId) {
+    public String getUsername(String sessionId) {
         return usernameBySessionId.containsKey(sessionId) ? usernameBySessionId.get(sessionId) : null;
     }
 
-    public void put(String sessionId, String username) {
-        // TODO: Check if already there?
+    public void putSession(String sessionId, String username) throws Exception {
+        if (usernameBySessionId.containsKey(sessionId)) {
+            throw new Exception("Session with ID = " + sessionId + " already exists.");
+        }
 
         usernameBySessionId.put(sessionId, username);
     }

--- a/src/main/java/com/gmzcodes/chainchat/store/UsersStore.java
+++ b/src/main/java/com/gmzcodes/chainchat/store/UsersStore.java
@@ -1,6 +1,5 @@
 package com.gmzcodes.chainchat.store;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**

--- a/src/test/java/com/gmzcodes/chainchat/PhilTheServerTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/PhilTheServerTest.java
@@ -1,12 +1,8 @@
 package com.gmzcodes.chainchat;
 
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
-import static org.powermock.api.support.membermodification.MemberModifier.stub;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 
-import io.vertx.core.http.HttpClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/gmzcodes/chainchat/constants/DefaultStoresValues.java
+++ b/src/test/java/com/gmzcodes/chainchat/constants/DefaultStoresValues.java
@@ -21,14 +21,7 @@ import io.vertx.core.json.JsonObject;
 public final class DefaultStoresValues {
     private DefaultStoresValues() {}
 
-    public final static BotsStore BOTS_STORE = initializeBotsStore();
-    public final static ConversationsStore CONVERSATIONS_STORE = initializeConversationsStore();
-    public final static SessionsStore SESSIONS_STORE = initializeSessionsStore();
-    public final static TokensStore TOKENS_STORE = initializeTokensStore();
-    public final static UsersStore USERS_STORE = initializeUsersStore();
-    public final static WebSocketsStore WEB_SOCKETS_STORE = initializeWebSocketsStore();
-
-    private static BotsStore initializeBotsStore() {
+    public static BotsStore BOTS_STORE() {
         BotsStore botsStore = new BotsStore();
 
         try {
@@ -53,50 +46,25 @@ public final class DefaultStoresValues {
         return botsStore;
     }
 
-    private static ConversationsStore initializeConversationsStore() {
+    public static ConversationsStore CONVERSATIONS_STORE() {
         ConversationsStore conversationsStore = new ConversationsStore();
-
-        Conversation aliceBob = new Conversation("alice", "bob");
-        Conversation aliceChris = new Conversation("alice", "chris");
-
-        List aliceConversations = new Stack();
-        aliceConversations.add(aliceBob);
-        aliceConversations.add(aliceChris);
-
-        List bobConversartions = new Stack();
-        bobConversartions.add(aliceBob);
-
-        List chrisConversartions = new Stack();
-        chrisConversartions.add(aliceChris);
-
-        HashMap<String, List<Conversation>> conversationsByUser = new HashMap<String, List<Conversation>>();
-
-        conversationsByUser.put("alice", aliceConversations);
-        conversationsByUser.put("bob", bobConversartions);
-        conversationsByUser.put("chris", chrisConversartions);
-
-        Whitebox.setInternalState(conversationsStore, "conversationsByUser", conversationsByUser);
-
-        // TODO: Mock some messages!
-
-        // TODO: Test users that have talked before and some others than haven't!
 
         return conversationsStore;
     }
 
-    private static SessionsStore initializeSessionsStore() {
+    public static SessionsStore SESSIONS_STORE() {
         SessionsStore sessionsStore = new SessionsStore();
 
         return sessionsStore;
     }
 
-    private static TokensStore initializeTokensStore() {
+    public static TokensStore TOKENS_STORE() {
         TokensStore tokensStore = new TokensStore();
 
         return tokensStore;
     }
 
-    private static UsersStore initializeUsersStore() {
+    public static UsersStore USERS_STORE() {
         UsersStore usersStore = new UsersStore();
 
         JsonObject users = new JsonObject();
@@ -126,7 +94,7 @@ public final class DefaultStoresValues {
         return usersStore;
     }
 
-    private static WebSocketsStore initializeWebSocketsStore() {
+    public static WebSocketsStore WEB_SOCKETS_STORE() {
         WebSocketsStore webSocketsStore = new WebSocketsStore();
 
         return webSocketsStore;

--- a/src/test/java/com/gmzcodes/chainchat/constants/DummyMessagesValues.java
+++ b/src/test/java/com/gmzcodes/chainchat/constants/DummyMessagesValues.java
@@ -1,0 +1,66 @@
+package com.gmzcodes.chainchat.constants;
+
+import com.gmzcodes.chainchat.store.BotsStore;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Created by danigamez on 14/12/2016.
+ */
+public final class DummyMessagesValues {
+    private DummyMessagesValues() {}
+
+    public final static JsonObject SRC_MESSAGE_ALICE_1 = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.00.000")
+            .put("message", "Hi Bob!");
+
+    public final static JsonObject SRC_MESSAGE_ALICE_2 = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.01.000")
+            .put("message", "How r u?");
+
+    public final static JsonObject SRC_DUPLICATED_MESSAGE_ALICE = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.03.000")
+            .put("message", "Wanna go for a drink tonight?");
+
+    public final static JsonObject FINAL_MESSAGE_ALICE_1 = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.00.000")
+            .put("id", "alice::2016.01.01.12.00.00.000")
+            .put("message", "Hi Bob!");
+
+    public final static JsonObject FINAL_MESSAGE_ALICE_2 = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.01.000")
+            .put("id", "alice::2016.01.01.12.00.01.000")
+            .put("message", "How r u?");
+
+    public final static JsonObject FINAL_DUPLICATED_FIRST_MESSAGE_ALICE = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.03.000")
+            .put("id", "alice::2016.01.01.12.00.03.000")
+            .put("message", "Wanna go for a drink tonight?");
+
+    public final static JsonObject FINAL_DUPLICATED_SECOND_MESSAGE_ALICE = new JsonObject()
+            .put("type", "msg")
+            .put("username", "alice")
+            .put("to", "bob")
+            .put("timestamp", "2016.01.01.12.00.03.000")
+            .put("id", "alice::2016.01.01.12.00.03.000.1")
+            .put("message", "Wanna go for a drink tonight?");
+
+}

--- a/src/test/java/com/gmzcodes/chainchat/constants/ExpectedValues.java
+++ b/src/test/java/com/gmzcodes/chainchat/constants/ExpectedValues.java
@@ -17,24 +17,26 @@ public final class ExpectedValues {
     public static final String PASS_BOB = "bob1234";
     public static final String PASS_CHRIS = "chris1234";
 
+    // TODO: Sync with DefaultStoreValues!
+
     public static final JsonObject USER_ALICE = new JsonObject()
             .put("username", USERNAME_ALICE)
             .put("name", "Alice Clinton")
-            .put("contacts", new JsonArray().add("bob").add("chris"))
-            .put("conversations", new JsonArray())
+            .put("contacts", new JsonArray().add("bob").add("chris").add("francis"))
+            .put("conversations", new JsonObject())
             .put("token", "@PRESENT");
 
     public static final JsonObject USER_BOB = new JsonObject()
             .put("username", USERNAME_BOB)
             .put("name", "Bob Trump")
             .put("contacts", new JsonArray().add("alice"))
-            .put("conversations", new JsonArray())
+            .put("conversations", new JsonObject())
             .put("token", "@PRESENT");
 
     public static final JsonObject USER_CHRIS = new JsonObject()
             .put("username", USERNAME_CHRIS)
             .put("name", "Chris Sambora")
             .put("contacts", new JsonArray().add("alice"))
-            .put("conversations", new JsonArray())
+            .put("conversations", new JsonObject())
             .put("token", "@PRESENT");
 }

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketBotEchoTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketBotEchoTest.java
@@ -2,6 +2,7 @@ package com.gmzcodes.chainchat.handlers.websocket;
 
 import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
 import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 
 import org.junit.After;
 import org.junit.Before;
@@ -12,8 +13,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -41,8 +42,8 @@ public class WebSocketBotEchoTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketBotPingPongTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketBotPingPongTest.java
@@ -1,6 +1,8 @@
 package com.gmzcodes.chainchat.handlers.websocket;
 
-import static com.gmzcodes.chainchat.constants.ExpectedValues.*;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 
 import org.junit.After;
 import org.junit.Before;
@@ -11,8 +13,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -40,8 +42,8 @@ public class WebSocketBotPingPongTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketConversationOfflineTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketConversationOfflineTest.java
@@ -1,7 +1,11 @@
 package com.gmzcodes.chainchat.handlers.websocket;
 
-import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
-import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.*;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -12,12 +16,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -41,8 +46,8 @@ public class WebSocketConversationOfflineTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });
@@ -61,30 +66,80 @@ public class WebSocketConversationOfflineTest {
     }
 
     @Test
-    public void conversationOfflineTest(TestContext context) {
-        /*
+    public void oneMessageSentStoredAckAndLoginAfterwardsTest(TestContext context) {
         final Async async = context.async();
 
-        MultiMap headers = new CaseInsensitiveHeaders();
-        headers.add(COOKIE, cookies.get());
+        JsonObject req = testClient.getGenericMessage(USERNAME_ALICE, USERNAME_BOB);
+        JsonObject ackResponse = new JsonObject()
+                .put("type", "stored")
+                .put("value", USERNAME_ALICE + "::" + req.getString("timestamp")); // TODO: Use function!
 
-        HttpClient httpClient = client.websocket(PORT, "localhost", "/eventbus", headers, ws -> {
-            ws.handler(buffer -> {
-                JsonObject expected = new JsonObject()
-                        .put("type", "ack")
-                        .put("value", "2016.10.10.12.00.00.000");
+        testClient.send(context, client, USERNAME_ALICE, req, ackResponse, done -> {
+            assertEquals(1, testSetup.getConversationsStore().get(USERNAME_ALICE, USERNAME_BOB).toJson().size());
 
-                System.out.println(new JsonObject(buffer.toString()).getString("value"));
+            // TODO: All these should be better handled in the EXPECTED_VALUE constants!
 
-                assertJsonEquals(context, expected, new JsonObject(buffer.toString()));
+            testClient.login(context, client, USERNAME_BOB, PASS_BOB, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_BOB, loginResponseJson, false);
 
-                ws.close();
+                JsonObject storedReq1 = req.copy().put("id", "alice::2016.10.10.12.00.00.000");
+                storedReq1.remove("token");
+
+                context.assertNotNull(loginResponseJson.getJsonObject("conversations"));
+                context.assertEquals(1, loginResponseJson.getJsonObject("conversations").size());
+                context.assertNotNull(loginResponseJson.getJsonObject("conversations").getJsonArray("alice"));
+                context.assertEquals(1, loginResponseJson.getJsonObject("conversations").getJsonArray("alice").size());
+                context.assertEquals(storedReq1, loginResponseJson.getJsonObject("conversations").getJsonArray("alice").getJsonObject(0));
 
                 async.complete();
             });
-
-            ws.write(Buffer.buffer("{ \"type\": \"msg\", \"timestamp\": \"2016.10.10.12.00.00.000\", \"username\": \"alice\", \"token\": \"" + token + "\", \"to\": \"bob\", \"value\": \"Hi\" }"));
         });
-        */
+    }
+
+    @Test
+    public void oneChatStoredAckAndLoginAfterwardsTest(TestContext context) {
+        final Async async = context.async();
+
+        JsonObject req = testClient.getGenericMessage(USERNAME_ALICE, USERNAME_BOB);
+        JsonObject ackResponse1 = new JsonObject()
+                .put("type", "stored")
+                .put("value", USERNAME_ALICE + "::" + req.getString("timestamp")); // TODO: Use helper function!
+        JsonObject ackResponse2 = new JsonObject()
+                .put("type", "stored")
+                .put("value", USERNAME_ALICE + "::" + req.getString("timestamp") + ".1"); // TODO: Use helper function!
+
+        List<JsonObject> conversation = new ArrayList<>();
+
+        conversation.add(new JsonObject().put("action", "send").put("value", req));
+        conversation.add(new JsonObject().put("action", "recv").put("value", ackResponse1));
+        conversation.add(new JsonObject().put("action", "send").put("value", req));
+        conversation.add(new JsonObject().put("action", "recv").put("value", ackResponse2));
+
+        testClient.chat(context, client, USERNAME_ALICE, conversation, done -> {
+            context.assertEquals(2, testSetup.getConversationsStore().get(USERNAME_ALICE, USERNAME_BOB).toJson().size());
+
+            JsonObject storedReq1 = req.copy().put("id", "alice::2016.10.10.12.00.00.000");
+            storedReq1.remove("token");
+            JsonObject storedReq2 = req.copy().put("id", "alice::2016.10.10.12.00.00.000.1");
+            storedReq2.remove("token");
+
+            context.assertEquals(storedReq1, testSetup.getConversationsStore().get(USERNAME_ALICE, USERNAME_BOB).toJson().getJsonObject(0));
+            context.assertEquals(storedReq2, testSetup.getConversationsStore().get(USERNAME_ALICE, USERNAME_BOB).toJson().getJsonObject(1));
+
+            // TODO: All these should be better handled in the EXPECTED_VALUE constants!
+
+            testClient.login(context, client, USERNAME_BOB, PASS_BOB, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_BOB, loginResponseJson, false);
+
+                context.assertNotNull(loginResponseJson.getJsonObject("conversations"));
+                context.assertEquals(1, loginResponseJson.getJsonObject("conversations").size());
+                context.assertNotNull(loginResponseJson.getJsonObject("conversations").getJsonArray("alice"));
+                context.assertEquals(2, loginResponseJson.getJsonObject("conversations").getJsonArray("alice").size());
+                context.assertEquals(storedReq1, loginResponseJson.getJsonObject("conversations").getJsonArray("alice").getJsonObject(0));
+                context.assertEquals(storedReq2, loginResponseJson.getJsonObject("conversations").getJsonArray("alice").getJsonObject(1));
+
+                async.complete();
+            });
+        });
     }
 }

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketConversationOnlineTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketConversationOnlineTest.java
@@ -1,6 +1,8 @@
 package com.gmzcodes.chainchat.handlers.websocket;
 
-import static com.gmzcodes.chainchat.constants.ExpectedValues.*;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 
 import org.junit.After;
 import org.junit.Before;
@@ -11,8 +13,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -40,8 +42,8 @@ public class WebSocketConversationOnlineTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketEndpointTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketEndpointTest.java
@@ -4,6 +4,7 @@ import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
 import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
 import static com.gmzcodes.chainchat.constants.ServerConfigValues.HOSTNAME;
 import static com.gmzcodes.chainchat.constants.ServerConfigValues.PATHNAME_WEBSOCKET;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 import static io.vertx.core.http.HttpHeaders.COOKIE;
 
 import org.junit.After;
@@ -15,14 +16,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -46,8 +48,8 @@ public class WebSocketEndpointTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsBotTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsBotTest.java
@@ -1,9 +1,10 @@
 package com.gmzcodes.chainchat.handlers.websocket;
 
-import static com.gmzcodes.chainchat.constants.ExpectedValues.*;
-import static com.gmzcodes.chainchat.contants.WebSocketErrorMessagesConstants.*;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
+import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
+import static com.gmzcodes.chainchat.contants.WebSocketErrorMessagesConstants.BLOCKED_BY_BOT;
+import static com.gmzcodes.chainchat.contants.WebSocketErrorMessagesConstants.INVALID_BOT;
 import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
-import static junit.framework.TestCase.assertNull;
 
 import org.junit.After;
 import org.junit.Before;
@@ -14,10 +15,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
-import com.gmzcodes.chainchat.bots.Bot;
-import com.gmzcodes.chainchat.store.BotsStore;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -46,8 +45,8 @@ public class WebSocketValidationsBotTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsGenericTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsGenericTest.java
@@ -16,8 +16,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -51,8 +51,8 @@ public class WebSocketValidationsGenericTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsHumanTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/handlers/websocket/WebSocketValidationsHumanTest.java
@@ -3,6 +3,7 @@ package com.gmzcodes.chainchat.handlers.websocket;
 import static com.gmzcodes.chainchat.constants.ExpectedValues.*;
 import static com.gmzcodes.chainchat.contants.WebSocketErrorMessagesConstants.INVALID_DESTINATION;
 import static com.gmzcodes.chainchat.contants.WebSocketErrorMessagesConstants.UNKNOWN_DESTINATION;
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 
 import org.junit.After;
 import org.junit.Before;
@@ -13,8 +14,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import com.gmzcodes.chainchat.PhilTheServer;
+import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
-import com.gmzcodes.chainchat.utils.TestClientEndToEnd;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
@@ -42,8 +43,8 @@ public class WebSocketValidationsHumanTest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/models/ConversationTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/models/ConversationTest.java
@@ -1,0 +1,509 @@
+package com.gmzcodes.chainchat.models;
+
+import static com.gmzcodes.chainchat.constants.DummyMessagesValues.*;
+import static junit.framework.TestCase.*;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Created by danigamez on 13/12/2016.
+ */
+public class ConversationTest {
+
+    @Before
+    public void setUp() {}
+
+    @After
+    public void tearDown() {}
+
+    @Test
+    public void conversationOneUserBuildId() {
+        assertEquals("user1", Conversation.buildRoomId("user1"));
+    }
+
+    @Test(expected=Exception.class)
+    public void conversationOneUserUnknownUserException() throws Exception {
+        Conversation conversation = new Conversation("user1");
+
+        try {
+            assertEquals("user1", conversation.getRoomIdForUser("user1"));
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        conversation.getRoomIdForUser("user");
+    }
+
+    @Test
+    public void conversationOneUserAndGetIndividualId() {
+        Conversation conversation = new Conversation("user1");
+
+        assertNotNull(conversation);
+        assertEquals("user1", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(1, usernames.size());
+        assertEquals("user1", usernames.get(0));
+
+        // Individual id:
+
+        try {
+            assertEquals("user1", conversation.getRoomIdForUser("user1"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationTwoSortedUserBuildId() {
+        assertEquals("user1::user2", Conversation.buildRoomId("user1", "user2"));
+    }
+
+    @Test(expected=Exception.class)
+    public void conversationTwoSortedUsersUnknownUserException() throws Exception {
+        Conversation conversation = new Conversation("user1", "user2");
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        conversation.getRoomIdForUser("user");
+    }
+
+    @Test
+    public void conversationTwoUsersSortedAndGetIndividualIds() {
+        Conversation conversation = new Conversation("user1", "user2");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(2, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationTwoUnsortedUserBuildId() {
+        assertEquals("user1::user2", Conversation.buildRoomId("user2", "user1"));
+    }
+
+    @Test(expected=Exception.class)
+    public void conversationTwoUnsortedUsersUnknownUserException() throws Exception {
+        Conversation conversation = new Conversation("user2", "user1");
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        conversation.getRoomIdForUser("user");
+    }
+
+    @Test
+    public void conversationTwoUsersUnsortedAndGetIndividualIds() {
+        Conversation conversation = new Conversation("user2", "user1");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(2, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationFiveSortedUserBuildId() {
+        assertEquals("user1::user2::user3::user4::user5", Conversation.buildRoomId("user1", "user2", "user3", "user4", "user5"));
+    }
+
+    @Test(expected=Exception.class)
+    public void conversationFiveSortedUsersUnknownUserException() throws Exception {
+        Conversation conversation = new Conversation("user1", "user2", "user3", "user4", "user5");
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        conversation.getRoomIdForUser("user");
+    }
+
+    @Test
+    public void conversationFiveUsersSortedAndGetIndividualIds() {
+        Conversation conversation = new Conversation("user1", "user2", "user3", "user4", "user5");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2::user3::user4::user5", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(5, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+        assertEquals("user3", usernames.get(2));
+        assertEquals("user4", usernames.get(3));
+        assertEquals("user5", usernames.get(4));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationFiveUnsortedUserBuildId() {
+        assertEquals("user1::user2::user3::user4::user5", Conversation.buildRoomId("user2", "user3", "user5", "user1", "user4"));
+    }
+
+    @Test(expected=Exception.class)
+    public void conversationFiveUnsortedUsersUnknownUserException() throws Exception {
+        Conversation conversation = new Conversation("user5", "user1", "user3", "user4", "user2");
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        conversation.getRoomIdForUser("user");
+    }
+
+    @Test
+    public void conversationFiveUsersUnsortedAndGetIndividualIds() {
+        Conversation conversation = new Conversation("user2", "user1", "user4", "user3", "user5");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2::user3::user4::user5", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(5, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+        assertEquals("user3", usernames.get(2));
+        assertEquals("user4", usernames.get(3));
+        assertEquals("user5", usernames.get(4));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationOneUserBuildIdRepeatedIgnored() {
+        assertEquals("user1", Conversation.buildRoomId("user1", "user1"));
+    }
+
+    @Test
+    public void conversationOneUserAndGetIndividualIdRepeatedIgnored() {
+        Conversation conversation = new Conversation("user1", "user1");
+
+        assertNotNull(conversation);
+        assertEquals("user1", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(1, usernames.size());
+        assertEquals("user1", usernames.get(0));
+
+        // Individual id:
+
+        try {
+            assertEquals("user1", conversation.getRoomIdForUser("user1"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationTwoSortedUserBuildIdRepeatedIgnored() {
+        assertEquals("user1::user2", Conversation.buildRoomId("user1", "user2", "user1"));
+    }
+
+    @Test
+    public void conversationTwoUsersSortedAndGetIndividualIdsRepeatedIgnored() {
+        Conversation conversation = new Conversation("user1", "user2", "user2");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(2, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationTwoUnsortedUserBuildIdRepeatedIgnored() {
+        assertEquals("user1::user2", Conversation.buildRoomId("user2", "user1", "user1"));
+    }
+
+    @Test
+    public void conversationTwoUsersUnsortedAndGetIndividualIdsRepeatedIgnored() {
+        Conversation conversation = new Conversation("user2", "user1", "user2");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(2, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1", conversation.getRoomIdForUser("user2"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationFiveSortedUserBuildIdRepeatedIgnored() {
+        assertEquals("user1::user2::user3::user4::user5", Conversation.buildRoomId("user1", "user4", "user2", "user3", "user4", "user5"));
+    }
+
+    @Test
+    public void conversationFiveUsersSortedAndGetIndividualIdsRepeatedIgnored() {
+        Conversation conversation = new Conversation("user1", "user2", "user3", "user1", "user4", "user5");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2::user3::user4::user5", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(5, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+        assertEquals("user3", usernames.get(2));
+        assertEquals("user4", usernames.get(3));
+        assertEquals("user5", usernames.get(4));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationFiveUnsortedUserBuildIdRepeatedIgnored() {
+        assertEquals("user1::user2::user3::user4::user5", Conversation.buildRoomId("user2", "user2", "user3", "user5", "user1", "user4"));
+    }
+
+    @Test
+    public void conversationFiveUsersUnsortedAndGetIndividualIdsRepeatedIgnored() {
+        Conversation conversation = new Conversation("user2", "user1", "user4", "user3", "user5", "user5");
+
+        assertNotNull(conversation);
+        assertEquals("user1::user2::user3::user4::user5", conversation.getRoomId());
+
+        // Internal state:
+
+        final List<String> usernames
+                = (List<String>) Whitebox.getInternalState(conversation, "usernames");
+
+        assertEquals(5, usernames.size());
+        assertEquals("user1", usernames.get(0));
+        assertEquals("user2", usernames.get(1));
+        assertEquals("user3", usernames.get(2));
+        assertEquals("user4", usernames.get(3));
+        assertEquals("user5", usernames.get(4));
+
+        // Individual id:
+
+        try {
+            assertEquals("user2::user3::user4::user5", conversation.getRoomIdForUser("user1"));
+            assertEquals("user1::user3::user4::user5", conversation.getRoomIdForUser("user2"));
+            assertEquals("user1::user2::user4::user5", conversation.getRoomIdForUser("user3"));
+            assertEquals("user1::user2::user3::user5", conversation.getRoomIdForUser("user4"));
+            assertEquals("user1::user2::user3::user4", conversation.getRoomIdForUser("user5"));
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+    @Test
+    public void conversationGetEmptyJson() {
+        Conversation conversation = new Conversation("user1");
+
+        JsonArray messages = conversation.toJson();
+
+        assertNotNull(messages);
+
+        assertEquals(0, messages.size());
+    }
+
+    @Test
+    public void conversationPutAndGetBackOneMessageJson() {
+        Conversation conversation = new Conversation("user1");
+
+        conversation.putMessage(SRC_MESSAGE_ALICE_1);
+
+        JsonArray messages = conversation.toJson();
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+        assertEquals(FINAL_MESSAGE_ALICE_1, messages.getJsonObject(0));
+    }
+
+    @Test
+    public void conversationPutAndGetBackTwoMessageJson() {
+        Conversation conversation = new Conversation("user1");
+
+        // TODO: Create default fake messages
+
+        conversation.putMessage(SRC_MESSAGE_ALICE_1);
+        conversation.putMessage(SRC_MESSAGE_ALICE_2);
+
+        JsonArray messages = conversation.toJson();
+
+        assertNotNull(messages);
+        assertEquals(2, messages.size());
+        assertEquals(FINAL_MESSAGE_ALICE_1, messages.getJsonObject(0));
+        assertEquals(FINAL_MESSAGE_ALICE_2, messages.getJsonObject(1));
+    }
+
+    @Test
+    public void conversationPutDuplicatedMessageJson() {
+        Conversation conversation = new Conversation("user1");
+
+        conversation.putMessage(SRC_DUPLICATED_MESSAGE_ALICE);
+        conversation.putMessage(SRC_DUPLICATED_MESSAGE_ALICE.copy());
+
+        JsonArray messages = conversation.toJson();
+
+        assertNotNull(messages);
+        assertEquals(2, messages.size());
+        assertEquals(FINAL_DUPLICATED_FIRST_MESSAGE_ALICE, messages.getJsonObject(0));
+        assertEquals(FINAL_DUPLICATED_SECOND_MESSAGE_ALICE, messages.getJsonObject(1));
+    }
+
+    // TODO: User not part of conversation test!
+}

--- a/src/test/java/com/gmzcodes/chainchat/models/TokenTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/models/TokenTest.java
@@ -1,17 +1,17 @@
 package com.gmzcodes.chainchat.models;
 
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.powermock.reflect.Whitebox;
-
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 /**
  * Created by Raul on 10/11/2016.

--- a/src/test/java/com/gmzcodes/chainchat/routes/api/auth/AuthAPITest.java
+++ b/src/test/java/com/gmzcodes/chainchat/routes/api/auth/AuthAPITest.java
@@ -5,14 +5,10 @@ import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
 import static com.gmzcodes.chainchat.constants.ServerConfigValues.HOSTNAME;
 import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 import static io.vertx.core.http.HttpHeaders.COOKIE;
-import static io.vertx.core.http.HttpHeaders.SET_COOKIE;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
 import org.junit.Before;
@@ -27,12 +23,8 @@ import com.gmzcodes.chainchat.utils.TestClient;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -55,8 +47,8 @@ public class AuthAPITest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/routes/api/user/UserAPITest.java
+++ b/src/test/java/com/gmzcodes/chainchat/routes/api/user/UserAPITest.java
@@ -1,15 +1,10 @@
-package com.gmzcodes.chainchat;
+package com.gmzcodes.chainchat.routes.api.user;
 
 import static com.gmzcodes.chainchat.constants.ExpectedValues.PASS_ALICE;
 import static com.gmzcodes.chainchat.constants.ExpectedValues.USERNAME_ALICE;
 import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
 import static io.vertx.core.http.HttpHeaders.COOKIE;
-import static io.vertx.core.http.HttpHeaders.SET_COOKIE;
 import static junit.framework.TestCase.assertTrue;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
 import org.junit.Before;
@@ -19,13 +14,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
+import com.gmzcodes.chainchat.PhilTheServer;
 import com.gmzcodes.chainchat.constants.ExpectedValues;
 import com.gmzcodes.chainchat.utils.TestClient;
 import com.gmzcodes.chainchat.utils.TestSetupEndToEnd;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.json.JsonArray;
@@ -52,8 +46,8 @@ public class UserAPITest {
         testSetup = new TestSetupEndToEnd(context, ctx -> {
             // GET CLIENTS:
 
-            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, identifier -> {
-                context.assertEquals("alice@1", identifier);
+            testClient.login(context, client, USERNAME_ALICE, PASS_ALICE, loginResponseJson -> {
+                assertJsonEquals(context, ExpectedValues.USER_ALICE, loginResponseJson, false);
 
                 async.complete();
             });

--- a/src/test/java/com/gmzcodes/chainchat/store/BotStoreTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/store/BotStoreTest.java
@@ -37,7 +37,7 @@ public class BotStoreTest {
 
         // ACTION: Get non-existing bot.
 
-        Bot bot1 = bots.get("bot1");
+        Bot bot1 = botsStore.get("bot1");
 
         // RESULTS:
 
@@ -121,6 +121,8 @@ public class BotStoreTest {
 
         try {
             botsStore.put("bot1", bot1);
+
+            assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
         }
@@ -178,6 +180,8 @@ public class BotStoreTest {
 
         try {
             botsStore.put("bot1", bot2);
+
+            assertTrue(false);
         } catch (Exception e) {
             assertTrue(true);
         }
@@ -228,7 +232,7 @@ public class BotStoreTest {
         try {
             botsStore.put("bot2", bot1);
         } catch (Exception e) {
-            assertTrue(true);
+            assertTrue(false);
         }
 
         // RESULTS:

--- a/src/test/java/com/gmzcodes/chainchat/store/ConversationStoreTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/store/ConversationStoreTest.java
@@ -1,0 +1,166 @@
+package com.gmzcodes.chainchat.store;
+
+import static com.gmzcodes.chainchat.utils.JsonAssert.assertJsonEquals;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import com.gmzcodes.chainchat.models.Conversation;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Created by danigamez on 13/12/2016.
+ */
+public class ConversationStoreTest {
+
+    @Before
+    public void setUp() {}
+
+    @After
+    public void tearDown() {}
+
+    @Test
+    public void getNonExistingJSONTest() {
+        final ConversationsStore conversationsStore = new ConversationsStore();
+        final HashMap<String, List<Conversation>> conversationsByUser
+                = (HashMap<String, List<Conversation>>) Whitebox.getInternalState(conversationsStore, "conversationsByUser");
+        final HashMap<String, Conversation> conversationsById
+                = (HashMap<String, Conversation>) Whitebox.getInternalState(conversationsStore, "conversationsById");
+
+        // PRE:
+
+        assertEquals(0, conversationsByUser.size());
+        assertEquals(0, conversationsById.size());
+
+        // ACTION: Get non existing conversation JSON.
+
+        JsonObject emptyJsonObject = conversationsStore.getJson("user1");
+
+        // RESULTS:
+
+        assertNotNull(emptyJsonObject);
+        assertEquals(0, emptyJsonObject.size());
+
+        // POST:
+
+        assertEquals(0, conversationsByUser.size());
+        assertEquals(0, conversationsById.size());
+    }
+
+    @Test
+    public void getNonExistingTwoUsersConversationAndCheckJSONTest() {
+        final ConversationsStore conversationsStore = new ConversationsStore();
+        final HashMap<String, List<Conversation>> conversationsByUser
+                = (HashMap<String, List<Conversation>>) Whitebox.getInternalState(conversationsStore, "conversationsByUser");
+        final HashMap<String, Conversation> conversationsById
+                = (HashMap<String, Conversation>) Whitebox.getInternalState(conversationsStore, "conversationsById");
+
+        // PRE:
+
+        assertEquals(0, conversationsByUser.size());
+        assertEquals(0, conversationsById.size());
+
+        // ACTION: Get non existing conversation for user1 and user2
+
+        Conversation conversationUser1User2 = conversationsStore.get("user1", "user2");
+        Conversation conversationUser2User1 = conversationsStore.get("user2", "user1");
+
+        JsonObject conversationsJsonUser1 = conversationsStore.getJson("user1");
+        JsonObject conversationsJsonUser2 = conversationsStore.getJson("user2");
+
+        // RESULTS:
+
+        assertNotNull(conversationUser1User2);
+        assertNotNull(conversationUser2User1);
+        assertEquals(conversationUser1User2, conversationUser2User1);
+        assertEquals("user1::user2", conversationUser1User2.getRoomId());
+        assertEquals("user1::user2", conversationUser2User1.getRoomId());
+
+        JsonObject expectedUser1JSON = new JsonObject()
+                .put("user2", new JsonArray());
+
+        JsonObject expectedUser2JSON = new JsonObject()
+                .put("user1", new JsonArray());
+
+        assertJsonEquals(expectedUser1JSON, conversationsJsonUser1);
+        assertJsonEquals(expectedUser2JSON, conversationsJsonUser2);
+
+        // This next part could be removed, assertJsonEquals is supposed to do that already (TODO: Add strict mode):
+
+        assertNotNull(conversationsJsonUser1);
+        assertNotNull(conversationsJsonUser2);
+        assertEquals(1, conversationsJsonUser1.size());
+        assertEquals(1, conversationsJsonUser2.size());
+        assertNotNull(conversationsJsonUser1.getJsonArray("user2"));
+        assertNotNull(conversationsJsonUser2.getJsonArray("user1"));
+        assertEquals(0, conversationsJsonUser1.getJsonArray("user2").size());
+        assertEquals(0, conversationsJsonUser2.getJsonArray("user1").size());
+
+        // POST:
+
+        assertEquals(2, conversationsByUser.size());
+        assertEquals(1, conversationsByUser.get("user1").size());
+        assertEquals(1, conversationsByUser.get("user2").size());
+        assertEquals(conversationUser1User2, conversationsByUser.get("user1").get(0));
+        assertEquals(conversationUser2User1, conversationsByUser.get("user2").get(0));
+
+        assertEquals(1, conversationsById.size());
+        assertEquals(conversationUser1User2, conversationsById.get("user1::user2"));
+    }
+
+    @Test
+    public void getNonExistingSelfUsersConversationAndCheckJSONTest() {
+        final ConversationsStore conversationsStore = new ConversationsStore();
+        final HashMap<String, List<Conversation>> conversationsByUser
+                = (HashMap<String, List<Conversation>>) Whitebox.getInternalState(conversationsStore, "conversationsByUser");
+        final HashMap<String, Conversation> conversationsById
+                = (HashMap<String, Conversation>) Whitebox.getInternalState(conversationsStore, "conversationsById");
+
+        // PRE:
+
+        assertEquals(0, conversationsByUser.size());
+        assertEquals(0, conversationsById.size());
+
+        // ACTION: Get non existing conversation for user1 and user2
+
+        Conversation conversationUser1 = conversationsStore.get("user1");
+
+        JsonObject conversationsJsonUser1 = conversationsStore.getJson("user1");
+
+        // RESULTS:
+
+        assertNotNull(conversationUser1);
+        assertEquals("user1", conversationUser1.getRoomId());
+
+        assertNotNull(conversationsJsonUser1);
+        assertEquals(1, conversationsJsonUser1.size());
+        assertNotNull(conversationsJsonUser1.getJsonArray("user1"));
+        assertEquals(0, conversationsJsonUser1.getJsonArray("user1").size());
+
+        JsonObject expectedUser1JSON = new JsonObject()
+                .put("user1", new JsonArray());
+
+        assertJsonEquals(expectedUser1JSON, conversationsJsonUser1);
+
+        // This next part could be removed, assertJsonEquals is supposed to do that already (TODO: Add strict mode):
+
+        // POST:
+
+        assertEquals(1, conversationsByUser.size());
+        assertEquals(1, conversationsByUser.get("user1").size());
+        assertEquals(conversationUser1, conversationsByUser.get("user1").get(0));
+
+        assertEquals(1, conversationsById.size());
+        assertEquals(conversationUser1, conversationsById.get("user1"));
+    }
+}

--- a/src/test/java/com/gmzcodes/chainchat/store/SessionsStoreTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/store/SessionsStoreTest.java
@@ -1,0 +1,329 @@
+package com.gmzcodes.chainchat.store;
+
+import static junit.framework.TestCase.*;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.impl.ServerWebSocketImpl;
+
+/**
+ * Created by danigamez on 09/11/2016.
+ */
+public class SessionsStoreTest {
+
+    @Before
+    public void setUp() {}
+
+    @After
+    public void tearDown() {}
+
+    @Test
+    public void getNonExistingTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Get non-existing session.
+
+        String username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNull(username);
+
+        // POST:
+
+        assertEquals(0, usernameBySessionId.size());
+    }
+
+    @Test
+    public void putOneSessionAndGetItBackTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 1 session for 1 user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+
+        String session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+
+        // POST:
+
+        assertEquals(1, usernameBySessionId.size());
+    }
+
+    @Test
+    public void putTwoSessionsForSameUserAndGetThemBackTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 2 session for same user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+            sessionsStore.putSession("session2", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+        String session2username = sessionsStore.getUsername("session2");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertNotNull(session2username);
+        assertEquals("user1", session1username);
+        assertEquals("user1", session2username);
+
+        // POST:
+
+        assertEquals(2, usernameBySessionId.size());
+    }
+
+    @Test
+    public void putTwoSessionsForDifferentUsersAndGetThemBackTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 2 session for 2 different users.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+            sessionsStore.putSession("session2", "user2");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+        String session2username = sessionsStore.getUsername("session2");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertNotNull(session2username);
+        assertEquals("user1", session1username);
+        assertEquals("user2", session2username);
+
+        // POST:
+
+        assertEquals(2, usernameBySessionId.size());
+    }
+
+    @Test
+    public void overwriteSessionForSameUserTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 1 session for 1 user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+
+        // PRE/POST:
+
+        assertEquals(1, usernameBySessionId.size());
+
+        // ACTION: Try to put that same session for same user.
+
+        // DON'T USE @Test(expected=Exception.class) in order to check internal state after Exception is thrown!
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+        }
+
+        session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+    }
+
+    @Test
+    public void overwriteSessionForDifferentUserTest() {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 1 session for 1 user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+
+        // PRE/POST:
+
+        assertEquals(1, usernameBySessionId.size());
+
+        // ACTION: Try to put that same session for same user.
+
+        // DON'T USE @Test(expected=Exception.class) in order to check internal state after Exception is thrown!
+
+        try {
+            sessionsStore.putSession("session1", "user2");
+
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(true);
+        }
+
+        session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+    }
+
+    @Test(expected=Exception.class)
+    public void overwriteSessionForSameUserExceptionTest() throws Exception {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 1 session for 1 user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+
+        // PRE/POST:
+
+        assertEquals(1, usernameBySessionId.size());
+
+        // ACTION: Try to put that same session for same user.
+
+        sessionsStore.putSession("session1", "user1");
+    }
+
+    @Test(expected=Exception.class)
+    public void overwriteSessionForDifferentUserExceptionTest() throws Exception {
+        final SessionsStore sessionsStore = new SessionsStore();
+        final HashMap<String, String> usernameBySessionId
+                = (HashMap<String, String>) Whitebox.getInternalState(sessionsStore, "usernameBySessionId");
+
+        // PRE:
+
+        assertEquals(0, usernameBySessionId.size());
+
+        // ACTION: Put 1 session for 1 user.
+
+        try {
+            sessionsStore.putSession("session1", "user1");
+
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        String session1username = sessionsStore.getUsername("session1");
+
+        // RESULTS:
+
+        assertNotNull(session1username);
+        assertEquals("user1", session1username);
+
+        // PRE/POST:
+
+        assertEquals(1, usernameBySessionId.size());
+
+        // ACTION: Try to put that same session for same user.
+
+        sessionsStore.putSession("session1", "user2");
+    }
+}

--- a/src/test/java/com/gmzcodes/chainchat/store/TokensStoreTest.java
+++ b/src/test/java/com/gmzcodes/chainchat/store/TokensStoreTest.java
@@ -1,14 +1,6 @@
 package com.gmzcodes.chainchat.store;
 
-import com.gmzcodes.chainchat.store.TokensStore;
-import com.gmzcodes.chainchat.models.Token;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.powermock.reflect.Whitebox;
-
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 
 import java.lang.reflect.Field;
@@ -16,6 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.gmzcodes.chainchat.models.Token;
 
 /**
  * Created by Raul on 10/11/2016.

--- a/src/test/java/com/gmzcodes/chainchat/utils/JsonAssert.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/JsonAssert.java
@@ -1,5 +1,11 @@
 package com.gmzcodes.chainchat.utils;
 
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
 import java.util.Map;
 
 import io.vertx.core.json.JsonArray;
@@ -10,11 +16,17 @@ import io.vertx.ext.unit.TestContext;
  * Created by danigamez on 10/11/2016.
  */
 public final class JsonAssert {
-    private JsonAssert() {}
+    private JsonAssert() {
+    }
+
+    // TODO: TEST TEST!!
 
     public static void assertJsonEquals(TestContext context, String message, JsonObject expected, JsonObject current, boolean strict) {
         // TODO: Implement messages support.
         // TODO: Implement strict mode.
+
+        context.assertNotNull(expected);
+        context.assertNotNull(current);
 
         for (Map.Entry<String, Object> entry : expected) {
             String key = entry.getKey();
@@ -23,13 +35,18 @@ public final class JsonAssert {
             context.assertTrue(current.containsKey(key), current.toString());
 
             if (value instanceof JsonObject) {
-                assertJsonEquals(context, message, (JsonObject)value, current.getJsonObject(key), strict);
+                context.assertTrue(current.getMap().get(key) instanceof JsonObject || current.getMap().get(key) instanceof Map);
+
+                assertJsonEquals(context, message, (JsonObject) value, current.getJsonObject(key), strict);
             } else if (value instanceof JsonArray) {
-                // TODO: context.assertTrue(false);
+                context.assertTrue(current.getMap().get(key) instanceof JsonArray || current.getMap().get(key) instanceof List);
+
+                assertJsonEquals(context, message, (JsonArray) value, current.getJsonArray(key), strict);
             } else if (value instanceof String) {
                 if (((String) value).charAt(0) == '@') {
                     switch ((String) value) {
                         case "@PRESENT":
+                            // TODO: Implement! Not null?
                             context.assertTrue(true);
                             break;
 
@@ -37,6 +54,8 @@ public final class JsonAssert {
                             context.assertTrue(false);
                     }
                 } else {
+                    assertTrue(current.getMap().get(key) instanceof String);
+
                     context.assertEquals(value, current.getString(key));
                 }
             } else {
@@ -55,5 +74,178 @@ public final class JsonAssert {
 
     public static void assertJsonEquals(TestContext context, JsonObject expected, JsonObject current) {
         assertJsonEquals(context, expected, current, false);
+    }
+
+    public static void assertJsonEquals(TestContext context, String message, JsonArray expected, JsonArray current, boolean strict) {
+        // TODO: Implement messages support.
+        // TODO: Implement strict mode.
+
+        // TODO: Array expected could also be a JsonObject with two fields: value and other properties such as unsorted: true or other checks
+
+        context.assertNotNull(expected);
+        context.assertNotNull(current);
+
+        int index = 0;
+
+        for (Object entry : expected) {
+            context.assertFalse(current.hasNull(index));
+            context.assertTrue(index < current.size());
+
+            if (entry instanceof JsonObject) {
+                context.assertTrue(current.getList().get(index) instanceof JsonObject);
+
+                assertJsonEquals(context, message, (JsonObject) entry, current.getJsonObject(index), strict);
+            } else if (entry instanceof JsonArray) {
+                context.assertTrue(current.getList().get(index) instanceof JsonArray);
+
+                assertJsonEquals(context, message, (JsonArray) entry, current.getJsonArray(index), strict);
+            } else if (entry instanceof String) {
+                if (((String) entry).charAt(0) == '@') {
+                    switch ((String) entry) {
+                        case "@PRESENT":
+                            context.assertTrue(true);
+                            break;
+
+                        default:
+                            context.assertTrue(false);
+                    }
+                } else {
+                    context.assertTrue(current.getList().get(index) instanceof String);
+
+                    context.assertEquals(entry, current.getString(index));
+                }
+            } else {
+                context.assertTrue(false);
+            }
+
+            ++index;
+        }
+    }
+
+    public static void assertJsonEquals(TestContext context, String message, JsonArray expected, JsonArray current) {
+        assertJsonEquals(context, message, expected, current, false);
+    }
+
+    public static void assertJsonEquals(TestContext context, JsonArray expected, JsonArray current, boolean strict) {
+        assertJsonEquals(context, null, expected, current, strict);
+    }
+
+    public static void assertJsonEquals(TestContext context, JsonArray expected, JsonArray current) {
+        assertJsonEquals(context, expected, current, false);
+    }
+
+    // NO CONTEXT
+
+    public static void assertJsonEquals(String message, JsonObject expected, JsonObject current, boolean strict) {
+        // TODO: Implement messages support.
+        // TODO: Implement strict mode.
+
+        assertNotNull(expected);
+        assertNotNull(current);
+
+        for (Map.Entry<String, Object> entry : expected) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            assertTrue(current.containsKey(key));
+
+            if (value instanceof JsonObject) {
+                assertTrue(current.getMap().get(key) instanceof JsonObject || current.getMap().get(key) instanceof Map);
+
+                assertJsonEquals(message, (JsonObject) value, current.getJsonObject(key), strict);
+            } else if (value instanceof JsonArray) {
+                assertTrue(current.getMap().get(key) instanceof JsonArray || current.getMap().get(key) instanceof List);
+
+                assertJsonEquals(message, (JsonArray) value, current.getJsonArray(key), strict);
+            } else if (value instanceof String) {
+                if (((String) value).charAt(0) == '@') {
+                    switch ((String) value) {
+                        case "@PRESENT":
+                            // TODO: Implement! Not null?
+                            assertTrue(true);
+                            break;
+
+                        default:
+                            assertTrue(false);
+                    }
+                } else {
+                    assertTrue(current.getMap().get(key) instanceof String);
+
+                    assertEquals(value, current.getString(key));
+                }
+            } else {
+                assertTrue(false);
+            }
+        }
+    }
+
+    public static void assertJsonEquals(String message, JsonObject expected, JsonObject current) {
+        assertJsonEquals(message, expected, current, false);
+    }
+
+    public static void assertJsonEquals(JsonObject expected, JsonObject current, boolean strict) {
+        assertJsonEquals((String) null, expected, current, strict);
+    }
+
+    public static void assertJsonEquals(JsonObject expected, JsonObject current) {
+        assertJsonEquals(expected, current, false);
+    }
+
+    public static void assertJsonEquals(String message, JsonArray expected, JsonArray current, boolean strict) {
+        // TODO: Implement messages support.
+        // TODO: Implement strict mode.
+
+        // TODO: Array expected could also be a JsonObject with two fields: value and other properties such as unsorted: true or other checks
+
+        assertNotNull(expected);
+        assertNotNull(current);
+
+        int index = 0;
+
+        for (Object entry : expected) {
+            assertFalse(current.hasNull(index));
+            assertTrue(index < current.size());
+
+            if (entry instanceof JsonObject) {
+                assertTrue(current.getList().get(index) instanceof JsonObject);
+
+                assertJsonEquals(message, (JsonObject) entry, current.getJsonObject(index), strict);
+            } else if (entry instanceof JsonArray) {
+                assertTrue(current.getList().get(index) instanceof JsonArray);
+
+                assertJsonEquals(message, (JsonArray) entry, current.getJsonArray(index), strict);
+            } else if (entry instanceof String) {
+                if (((String) entry).charAt(0) == '@') {
+                    switch ((String) entry) {
+                        case "@PRESENT":
+                            assertTrue(true);
+                            break;
+
+                        default:
+                            assertTrue(false);
+                    }
+                } else {
+                    assertTrue(current.getList().get(index) instanceof String);
+
+                    assertEquals(entry, current.getString(index));
+                }
+            } else {
+                assertTrue(false);
+            }
+
+            ++index;
+        }
+    }
+
+    public static void assertJsonEquals(String message, JsonArray expected, JsonArray current) {
+        assertJsonEquals(message, expected, current, false);
+    }
+
+    public static void assertJsonEquals(JsonArray expected, JsonArray current, boolean strict) {
+        assertJsonEquals((String) null, expected, current, strict);
+    }
+
+    public static void assertJsonEquals(JsonArray expected, JsonArray current) {
+        assertJsonEquals(expected, current, false);
     }
 }

--- a/src/test/java/com/gmzcodes/chainchat/utils/TestClient.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/TestClient.java
@@ -1,6 +1,7 @@
 package com.gmzcodes.chainchat.utils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.vertx.core.Handler;
@@ -17,8 +18,10 @@ public abstract class TestClient {
 
     // MAIN FUNCTIONALITY:
 
-    public abstract void login(TestContext context, HttpClient client, String username, String password, Handler<String> handler);
+    public abstract void login(TestContext context, HttpClient client, String username, String password, Handler<JsonObject> handler);
+    @Deprecated
     public abstract void send(TestContext context, HttpClient client, String clientId, JsonObject req, JsonObject res, Handler<Object> handler);
+    public abstract void chat(TestContext context, HttpClient client, String clientId, List<JsonObject> messages, Handler<Object> handler);
 
     // GETTERS:
 

--- a/src/test/java/com/gmzcodes/chainchat/utils/TestClientWebSocketHandlerUnit.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/TestClientWebSocketHandlerUnit.java
@@ -1,5 +1,7 @@
 package com.gmzcodes.chainchat.utils;
 
+import java.util.List;
+
 import com.gmzcodes.chainchat.store.SessionsStore;
 import com.gmzcodes.chainchat.store.TokensStore;
 import com.gmzcodes.chainchat.store.UsersStore;
@@ -24,12 +26,17 @@ public class TestClientWebSocketHandlerUnit extends TestClient {
     }
 
     @Override
-    public void login(TestContext context, HttpClient client, String username, String password, Handler<String> handler) {
+    public void login(TestContext context, HttpClient client, String username, String password, Handler<JsonObject> handler) {
 
     }
 
     @Override
     public void send(TestContext context, HttpClient client, String clientId, JsonObject req, JsonObject res, Handler<Object> handler) {
+
+    }
+
+    @Override
+    public void chat(TestContext context, HttpClient client, String clientId, List<JsonObject> messages, Handler<Object> handler) {
 
     }
 }

--- a/src/test/java/com/gmzcodes/chainchat/utils/TestSetup.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/TestSetup.java
@@ -1,5 +1,7 @@
 package com.gmzcodes.chainchat.utils;
 
+import org.powermock.reflect.Whitebox;
+
 import com.gmzcodes.chainchat.store.*;
 
 /**
@@ -12,4 +14,10 @@ public abstract class TestSetup {
     public abstract void setTokensStore(TokensStore tokensStore);
     public abstract void setUsersStore(UsersStore usersStore);
     public abstract void setWebSocketsStore(WebSocketsStore webSocketsStore);
+    public abstract BotsStore getBotsStore();
+    public abstract ConversationsStore getConversationsStore();
+    public abstract SessionsStore getSessionsStore();
+    public abstract TokensStore getTokensStore();
+    public abstract UsersStore getUsersStore();
+    public abstract WebSocketsStore getWebSocketsStore();
 }

--- a/src/test/java/com/gmzcodes/chainchat/utils/TestSetupEndToEnd.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/TestSetupEndToEnd.java
@@ -42,6 +42,13 @@ public class TestSetupEndToEnd extends TestSetup {
     }
 
     public TestSetupEndToEnd(TestContext context, Handler<AsyncResult<String>> ctx, boolean reinjectStores) {
+        final BotsStore BOTS_STORE = BOTS_STORE();
+        final ConversationsStore CONVERSATIONS_STORE = CONVERSATIONS_STORE();
+        final SessionsStore SESSIONS_STORE = SESSIONS_STORE();
+        final TokensStore TOKENS_STORE = TOKENS_STORE();
+        final UsersStore USERS_STORE = USERS_STORE();
+        final WebSocketsStore WEB_SOCKETS_STORE = WEB_SOCKETS_STORE();
+
         try {
             // Try to get a random PORT:
 
@@ -118,6 +125,30 @@ public class TestSetupEndToEnd extends TestSetup {
 
     public void setWebSocketsStore(WebSocketsStore webSocketsStore) {
         Whitebox.setInternalState(philTheServer, "webSocketsStore", webSocketsStore);
+    }
+
+    public BotsStore getBotsStore() {
+        return Whitebox.getInternalState(philTheServer, "botsStore");
+    }
+
+    public ConversationsStore getConversationsStore() {
+        return Whitebox.getInternalState(philTheServer, "conversationsStore");
+    }
+
+    public SessionsStore getSessionsStore() {
+        return Whitebox.getInternalState(philTheServer, "sessionsStore");
+    }
+
+    public TokensStore getTokensStore() {
+        return Whitebox.getInternalState(philTheServer, "tokensStore");
+    }
+
+    public UsersStore getUsersStore() {
+        return Whitebox.getInternalState(philTheServer, "usersStore");
+    }
+
+    public WebSocketsStore getWebSocketsStore() {
+        return Whitebox.getInternalState(philTheServer, "webSocketsStore");
     }
 
     // TEST SETUP END TO END SPECIFIC:

--- a/src/test/java/com/gmzcodes/chainchat/utils/TestSetupWebSocketHandlerUnit.java
+++ b/src/test/java/com/gmzcodes/chainchat/utils/TestSetupWebSocketHandlerUnit.java
@@ -17,14 +17,7 @@ import io.vertx.ext.unit.TestContext;
 public class TestSetupWebSocketHandlerUnit extends TestSetup {
     // Test subject:
 
-    private final WebSocketHandler webSocketHandler = new WebSocketHandler(
-            BOTS_STORE,
-            CONVERSATIONS_STORE,
-            SESSIONS_STORE,
-            TOKENS_STORE,
-            USERS_STORE,
-            WEB_SOCKETS_STORE
-    );
+    private final WebSocketHandler webSocketHandler;
 
     // Test client:
 
@@ -33,6 +26,22 @@ public class TestSetupWebSocketHandlerUnit extends TestSetup {
     // CONSTRUCTORS:
 
     public TestSetupWebSocketHandlerUnit(TestContext context, Handler<AsyncResult<String>> ctx) {
+        final BotsStore BOTS_STORE = BOTS_STORE();
+        final ConversationsStore CONVERSATIONS_STORE = CONVERSATIONS_STORE();
+        final SessionsStore SESSIONS_STORE = SESSIONS_STORE();
+        final TokensStore TOKENS_STORE = TOKENS_STORE();
+        final UsersStore USERS_STORE = USERS_STORE();
+        final WebSocketsStore WEB_SOCKETS_STORE = WEB_SOCKETS_STORE();
+
+        webSocketHandler = new WebSocketHandler(
+                BOTS_STORE,
+                CONVERSATIONS_STORE,
+                SESSIONS_STORE,
+                TOKENS_STORE,
+                USERS_STORE,
+                WEB_SOCKETS_STORE
+        );
+
         // This client needs to fake the logging data in the stores, therefor it needs a reference to them:
 
         testClient = new TestClientWebSocketHandlerUnit(
@@ -116,5 +125,29 @@ public class TestSetupWebSocketHandlerUnit extends TestSetup {
 
     public void setWebSocketsStore(WebSocketsStore webSocketsStore) {
         Whitebox.setInternalState(webSocketHandler, "webSocketsStore", webSocketsStore);
+    }
+
+    public BotsStore getBotsStore() {
+        return Whitebox.getInternalState(webSocketHandler, "botsStore");
+    }
+
+    public ConversationsStore getConversationsStore() {
+        return Whitebox.getInternalState(webSocketHandler, "conversationsStore");
+    }
+
+    public SessionsStore getSessionsStore() {
+        return Whitebox.getInternalState(webSocketHandler, "sessionsStore");
+    }
+
+    public TokensStore getTokensStore() {
+        return Whitebox.getInternalState(webSocketHandler, "tokensStore");
+    }
+
+    public UsersStore getUsersStore() {
+        return Whitebox.getInternalState(webSocketHandler, "usersStore");
+    }
+
+    public WebSocketsStore getWebSocketsStore() {
+        return Whitebox.getInternalState(webSocketHandler, "webSocketsStore");
     }
 }


### PR DESCRIPTION
- Updates WebSocketHandler to send ACK to the client when receiving a message and to store that message in the ConversationsStore.
- Updates Conversation to work for an arbitrary number of users and to keep messages and implements ConversationTest to check that all the new functionality works as expected: handling of duplicated users, generation of the room id, group conversations
- Updates AuthAPIRoutes to handle a possible duplicate when storing the session by returning a 500 error.
- Updates ConversationStore to create new conversations automatically when needed and to generate the Json versions of all the conversations from a given user and implements ConversationStoreTest to verify its functionality.
- Updates SessionStore to throw an exception if we try to save a duplicated session.
- Creates SessionStoreTest too to verify the new SessionStore functionality.
- Updates DefaultStoreValues and its usages to always return a fresh copy of them.
- Creates the DummyMessagesValues to help setting up the test data.
- Updates the ExpectedValues in order to match the changes in DefaultStoreValues.
- Updates TestClient#login to return the login result back to the calling context so that it can be verified in the test implementation and not in the helper class.
- Implements ConversationOfflineTest to which test that we can send multiple messages, that we get the ACKs back and that they are properly stored and retrieved by the receiver user once he logs in.
- Updates BotStoreTest to handle exception checks properly.
- Updates JsonAssert helper class to take JsonArrays into account and updates usages accordingly.
- Updates TestClient classes to handle verification of bidirectional flows of an arbitrary number of messages and deprecates the original send method which only works for one roundtrip.
 - Updates TestSetup classes to handle store classes properly, keep them in sync between the different classes which are injected with them and  set/reset them when needed.